### PR TITLE
Handle missing fetcher in Acquirer and Harvester

### DIFF
--- a/data-pipeline/pipeline/process/base/acquirer.py
+++ b/data-pipeline/pipeline/process/base/acquirer.py
@@ -6,7 +6,7 @@ class Acquirer(object):
         self.datacache = config["datacache"]
         self.recordcache = config["recordcache"]
         self.mapper = config["mapper"]
-        self.fetcher = config["fetcher"]
+        self.fetcher = config.get("fetcher", None)
         self.debug = config.get("debug", 0)
         self.name = config["name"]
         # self.force_rebuild = config.get("force_rebuild", False)
@@ -38,7 +38,7 @@ class Acquirer(object):
                 print(f"       Skipping {self.name}/{identifier} in acquire due to ignore_sources")
             return None
 
-        if self.fetcher.enabled:
+        if self.fetcher and getattr(self.fetcher, "enabled", False):
             rec = self.fetcher.fetch(identifier)
             if rec is None:
                 if self.debug:

--- a/data-pipeline/pipeline/process/base/harvester.py
+++ b/data-pipeline/pipeline/process/base/harvester.py
@@ -34,9 +34,12 @@ class Harvester(object):
         return what
 
     def crawl(self, last_harvest=None):
-        self.fetcher = self.config["fetcher"]
+        self.fetcher = self.config.get("fetcher", None)
         if self.fetcher is not None:
-            self.fetcher.enabled = True
+            try:
+                self.fetcher.enabled = True
+            except Exception:
+                pass
         self.seen = {}
         if last_harvest is not None:
             self.last_harvest = last_harvest


### PR DESCRIPTION
Guard against missing `fetcher` in configs to avoid KeyError during instantiate_all(). Adjust `Acquirer` and `Harvester` to use `config.get("fetcher")` and check for `.enabled` safely.